### PR TITLE
feat: Simplify SDK resource loading from v3.18.0

### DIFF
--- a/components/CameraCapture.tsx
+++ b/components/CameraCapture.tsx
@@ -196,7 +196,7 @@ export default function CameraCapture({ onClose }: CameraCaptureProps) {
         .setHostKey("<YOUR_SDKKEY>");
 
         unicoCameraRef.current = new SDK.UnicoCheckBuilder()
-          .setResourceDirectory("/resources")
+         // .setResourceDirectory("/resources") /*-- A partir da versão 3.18.0, o SDK busca os recursos adicionais automaticamente se o método setResourceDirectory não for usado e as configurações de CSP estiverem corretas. --*/
           .setModelsPath("/models")
           .setEnvironment(SDK.SDKEnvironmentTypes.UAT)
           .build();


### PR DESCRIPTION
# Description

Starting with version 3.18.0, the SDK automatically fetches additional resources.

With this update, implementing the `setResourceDirectory` method is no longer necessary for resource loading. Ensure that Content Security Policy (CSP) settings are correctly applied for the SDK to function properly.

# Demand

What demand does this Pull Request refer to?

- [ ] Bug
- [ ] Feature
- [X] update