### PR TITLE
Update unico-webframe to v3.22.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "tailwindcss": "3.3.7",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "5.2.2",
-    "unico-webframe": "3.22.5",
+    "unico-webframe": "3.22.6",
     "vaul": "^0.9.9",
     "zod": "^3.23.8"
   }


### PR DESCRIPTION

    Automatic update of `unico-webframe` to version **3.22.6** 📅 Release date: **29/01/2026** 🔗 [Official Release Notes](https://devcenter.unico.io/unico-idcloud/by-client-integration/pt/sdk/sdks-disponiveis/sdk-web/release-notes)

    📝 Release notes:
    - Atualização do SDK e server do Liveness com interação;
- Melhoria no timeout das chamadas HTTP;
    