### PR TITLE
Update unico-webframe to v3.23.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "tailwindcss": "3.3.7",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "5.2.2",
-    "unico-webframe": "3.23.7",
+    "unico-webframe": "3.23.9",
     "vaul": "^0.9.9",
     "zod": "^3.23.8"
   }


### PR DESCRIPTION

    Automatic update of `unico-webframe` to version **3.23.9** 📅 Release date: **20/05/2026** 🔗 [Official Release Notes](https://devcenter.unico.io/unico-idcloud/by-client-integration/pt/sdk/sdks-disponiveis/sdk-web/release-notes)

    📝 Release notes:
    - Melhorias internas de produto, ajustes e otimizações de segurança;
- Personalização da tela de consentimento do SDK.
    